### PR TITLE
Update README.md

### DIFF
--- a/backend_api/README.md
+++ b/backend_api/README.md
@@ -89,6 +89,7 @@ Start your virtual environment:
 Install the dependencies:
 
     pip install -r requirements.txt
+    (Other dependencies are flas_restx, google-cloud)
 
 Start your application via cloud shell using your virtual environment:
 


### PR DESCRIPTION
flask_restx, google-cloud are other packages required to run main.py - please add them after  pip install requirement.txt  Also, one will have to navigate to requirements.txt file to install the dependencies.  So flask_restx and google-cloud needs to be added to the requirements.txt file as an alternative step.

divya@DESKTOP-PC761NF MINGW64 /c/GCP-NLP-Flask/sample-gcp-nlp-flask/backend_api (master) $ python main.py
Traceback (most recent call last):
  File "main.py", line 4, in <module>
    from flask_restx import Resource, Api
ModuleNotFoundError: No module named 'flask_restx' (base)